### PR TITLE
Update central.maven.org repo to repo1.maven.org and use https

### DIFF
--- a/install_solr.sh
+++ b/install_solr.sh
@@ -6,7 +6,7 @@ if [ -z "$SOLR_USER" ]; then
   SOLR_USER=solr
 fi
 JTS_VERSION="1.15.0"
-JTS_URL="http://central.maven.org/maven2/org/locationtech/jts/jts-core/$JTS_VERSION/jts-core-$JTS_VERSION.jar"
+JTS_URL="https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/$JTS_VERSION/jts-core-$JTS_VERSION.jar"
 
 # Check if the correct version is already installed
 read -r REQUIRED_VERSION<"$DIR/required_solr_version"


### PR DESCRIPTION
http://central.maven.org appears to have been recently deprecated in favor of https://repo1.maven.org

As it is install_solr.sh currently downloads an error msg to ``jts-core-$version.jar`` and seems to proceed installing happily all the way to the end. Some additional error checking after downloading may be in order.